### PR TITLE
Fix dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # ignore debug files
 /debug
+
+# ignore .vscode
+/.vscode

--- a/ui/common/filter_frame.lua
+++ b/ui/common/filter_frame.lua
@@ -12,8 +12,6 @@ MTSLUI_FILTER_FRAME = {
     FRAME_WIDTH_HORIZONTAL = 515,
     -- height of the frame
     FRAME_HEIGHT = 110,
-    -- all available phases
-    phases= {},
     -- all contintents
     continents = {},
     -- all zones for each contintent
@@ -687,7 +685,6 @@ MTSLUI_FILTER_FRAME = {
             self.ui_frame.specialisation_drop_down:Hide()
             -- Update the list of specialisations for the current profession
             self:BuildSpecialisations()
-            self:CreateDropDownSpecialisations()
             -- Show it again after rebuild
             self.ui_frame.specialisation_drop_down:Show()
             self:UpdateFilters()

--- a/ui/common/filter_frame.lua
+++ b/ui/common/filter_frame.lua
@@ -66,15 +66,16 @@ MTSLUI_FILTER_FRAME = {
     ----------------------------------------------------------------------------------------------------------
     InitialiseFirstRow = function (self)
         -- Search box with button
-        self.ui_frame.search_box = CreateFrame("EditBox", self.filter_frame_name .. "_TF", self.ui_frame)
-        self.ui_frame.search_box:SetBackdrop({
-            bgFile = "Interface/Tooltips/UI-Tooltip-Background",
-            edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
-            tile = true,
-            tileSize = 16,
-            edgeSize = 16,
-            insets = { left = 4, right = 4, top = 4, bottom = 4 }
-        })
+        self.ui_frame.search_box = CreateFrame("EditBox", self.filter_frame_name .. "_TF", self.ui_frame, _G.BackdropTemplateMixin and "BackdropTemplate")
+		local backdropInfo = {
+			bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+			edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+			tile = true,
+			tileSize = 16,
+			edgeSize = 16,
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
+		}
+		self.ui_frame.search_box:SetBackdrop(backdropInfo)
         --  Black background
         self.ui_frame.search_box:SetBackdropColor(0,0,0,1)
         -- make cursor appear in the textbox

--- a/ui/locales.lua
+++ b/ui/locales.lua
@@ -1296,7 +1296,6 @@ MTSLUI_LOCALES_LABELS = {
         ["Russian"] = " уровня",
         ["Korean"] = "",
         ["Chinese"] = "",
-        ["Taiwanese"] = "",
         ["Spanish"] = "",
         ["Mexican"] = "",
         ["Portuguese"] = "",

--- a/ui/tools.lua
+++ b/ui/tools.lua
@@ -382,7 +382,7 @@ MTSLUI_TOOLS = {
 			-- keep it open so we can (un)check multiple items at once
 			info.keepShownOnClick = true
 			info.hasArrow = false
-			-- UIDropDownMenu_AddButton(info)
+			UIDropDownMenu_AddButton(info)
 		end
 	end,
 

--- a/ui/tools.lua
+++ b/ui/tools.lua
@@ -20,21 +20,24 @@ MTSLUI_TOOLS = {
 	-- returns			Frame		Returns the created frame
 	----------------------------------------------------------------------------------------
 	CreateBaseFrame = function (self, type, name, parent, template, width, height, has_backdrop)
-		local generic_frame = CreateFrame(type, name, parent, template)
+		if template == nil then
+			template = "BackdropTemplate"
+		end
+		local generic_frame = CreateFrame(type, name, parent, _G.BackdropTemplateMixin and template)
 		generic_frame:SetWidth(width)
 		generic_frame:SetHeight(height)
 		generic_frame:SetParent(parent)
 		-- Add a background to the frame if we want it
 		if has_backdrop ~= nil and has_backdrop == true then
-			generic_frame:SetBackdrop({
-				bgFile = "Interface/Tooltips/UI-Tooltip-Background",
-				edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
+			local backdropInfo = {
+				bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+				edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
 				tile = true,
 				tileSize = 16,
 				edgeSize = 16,
 				insets = { left = 4, right = 4, top = 4, bottom = 4 }
-			})
-			--  Black background
+			}
+			generic_frame:SetBackdrop(backdropInfo)
 			generic_frame:SetBackdropColor(0,0,0,1)
 		end
 		-- make sure mouse is captured on our window (NO clicking through)
@@ -160,7 +163,7 @@ MTSLUI_TOOLS = {
 		local TEXTURES_BUTTON = {
 			SELECTED = "Interface\\Buttons\\UI-Listbox-Highlight",
 			HIGHLIGHTED = "Interface\\Tooltips\\UI-Tooltip-Background",
-			NOT_SELECTED = "",
+			NOT_SELECTED = MTSLUI_ADDON_PATH .. "\\Images\\empty.blp",
 		}
 
 		local b = CreateFrame("Button", name, event_class.ui_frame)
@@ -379,7 +382,7 @@ MTSLUI_TOOLS = {
 			-- keep it open so we can (un)check multiple items at once
 			info.keepShownOnClick = true
 			info.hasArrow = false
-			UIDropDownMenu_AddButton(info)
+			-- UIDropDownMenu_AddButton(info)
 		end
 	end,
 


### PR DESCRIPTION
Fixes https://github.com/Thumbkin/MissingTradeSkillsList_Classic/issues/12

- https://github.com/Thumbkin/MissingTradeSkillsList_Classic/commit/4e43fca8a587a3703f73bd30490ad27ad63c7a4b just alignes repository with v1.15.51
- https://github.com/Thumbkin/MissingTradeSkillsList_Classic/commit/217b60978ad0ccb49bcaf2c4fa42b956c5adae9c - fix for dropdowns

From my understanding, the problem was caused by Specialization dropdown: CreateDropDownSpecializations() was being called during addon initialization; I guess, at this point there's not enough info to create that - so addon initialization was crashing.

Anyway, removing this line helps with addon initialization and dropdowns working
But, it is possible that it could create other bugs, for which I don't have enough testing capabilities